### PR TITLE
code review

### DIFF
--- a/Core.fs
+++ b/Core.fs
@@ -5,19 +5,18 @@ module Core =
 
     let run (Parser p) text = p text
 
-    let replacediacritics (x:string) = x.Replace("é", "e")
+    let replaceDiacritics (x:string) = 
+        x
+        |> System.Text.Encoding.GetEncoding("ISO-8859-8").GetBytes
+        |> System.Text.Encoding.UTF8.GetString
 
-    let prune source target = (source:string).IndexOf(target, System.StringComparison.InvariantCultureIgnoreCase) <> -1
+    let icontains source target = (source:string).IndexOf(target, System.StringComparison.InvariantCultureIgnoreCase) <> -1
 
     let parseAny list v =
         Parser <| fun text ->
-            if list |> List.exists (prune text) then Some v
+            if list |> List.exists (icontains text) then Some v
             else None
 
-    let combineWord a b =
-        [ sprintf "%s %s" a b
-          sprintf "%s %s" b a ]
-    
     module Operators =
         let (<|>) f g = 
             fun text ->

--- a/MealPlanParsing.fs
+++ b/MealPlanParsing.fs
@@ -2,37 +2,50 @@
 
 module MealPlanParsing =
     open Core
+    open Core.Operators
 
     type MealPlan =
         | BreakfastIncluded
         | BreakfastNotIncluded
-
-    let pBreakfast v =                   
-        parseAny            
-            [ //English
-              "breakfast"
+    
+    /// English
+    let pEnBreakfast v = 
+        v |> parseAny 
+            [ "breakfast"
               "include breakfast"
               "includes breakfast"
               "including breakfast"
               "breakfast included"
               "breakfast is included"
-              "with breakfast"
-              //Spanish
-              "desayuno incluido"
-              "incluye el desayuno"
-              //Portuguese
-              "inclui pequeno-almoco"
+              "with breakfast" ]
+    
+    let pEsBreakfast v = 
+        v |> parseAny
+            [ "desayuno incluido"
+              "incluye el desayuno" ]
+    
+    let pPtBreakfast v = 
+        v |> parseAny
+            [ "inclui pequeno-almoco"
               "pequeno-almoco incluido"
               "pequeno almoco incluido"
               "pequeno-almoco esta incluido"
-              "pequeno almoco esta incluido" 
-              //Icelandic
-              "innifalið morgunverðarhlaðborð" ]
-            v
+              "pequeno almoco esta incluido" ]
+    
+    let pIsBreakfast v = 
+        v |> parseAny [ "innifalið morgunverðarhlaðborð" ]
+    
+    //Compose lang by lang
+    let pBreakfast v = 
+        pEnBreakfast v 
+        <|> pEsBreakfast v
+        <|> pPtBreakfast v
+        <|> pIsBreakfast v
     
     let parseBreakfast = pBreakfast BreakfastIncluded
 
-    let pNotBreakfast v = 
+    //Compose all lang at one
+    let pNotIncludedBreakfast v = 
         parseAny
             [ //English
               "breakfast excluded"
@@ -46,10 +59,8 @@ module MealPlanParsing =
               "morgunverður er ekki innifalinn" ]
             v
 
-    let parseNotBreakfast = pNotBreakfast BreakfastNotIncluded
+    let parseNotBreakfast = pNotIncludedBreakfast BreakfastNotIncluded
     
-    open Core.Operators
-
     let parseAll = 
         parseNotBreakfast         
         <|> parseBreakfast

--- a/packages.config
+++ b/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Availpro.Text" version="1.2.5" targetFramework="net451" />
   <package id="FParsec" version="1.0.3" targetFramework="net451" />
   <package id="FSharp.Core" version="4.5.2" targetFramework="net451" />
   <package id="FSharp.Data" version="3.0.0" targetFramework="net451" />


### PR DESCRIPTION
Hello,

I removed the Availpro.Text because this dep is not used and not available of nuget.org.

I also separate by lang the breakfast case. The NotIncluded is interesting to start then split by using the lang shrink.

I supplied a complete version of the removediacretics.
